### PR TITLE
upgrade Compose relation library 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,9 +13,31 @@ ext {
 android {
     compileSdkVersion 30
     buildToolsVersion "30.0.3"
+    this.rootProject.buildscript.configurations.classpath
+            .resolvedConfiguration
+            .firstLevelModuleDependencies.
+            each {
+                def name = it.name
+                if (name.contains('com.android.tools.build:gradle')) {
+                    def moduleVersion = it.moduleVersion
+                    if (moduleVersion.contains("-")) {
+                        def alphaversionArray = moduleVersion.split("-")[0]
+                        def versionArray = alphaversionArray.toString().split("\\.")
+                        ext.android_builder_main_version = Integer.parseInt(versionArray[0])
+                        ext.android_builder_mid_version = Integer.parseInt(versionArray[1])
+                    } else {
+                        version = moduleVersion
+                        android_builder_version = moduleVersion
+                        ext.android_builder_main_version = Integer.parseInt(android_builder_version.split("\\.")[0])
+                        ext.android_builder_mid_version = Integer.parseInt(android_builder_version.split("\\.")[1])
+                    }
+                }
+            }
     defaultConfig {
         applicationId "com.example.androiddevchallenge.petadoption"
         minSdkVersion 23
+        //Android 23 get crash
+        // No static method hashCode(I)I in class Ljava/lang/Integer; or its super classes (declaration of 'java.lang.Integer' appears in /system/framework/core-libart.jar)
         targetSdkVersion 30
         versionCode 1
         versionName "1.0"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,9 +3,16 @@ plugins {
     id 'kotlin-android'
 }
 
+def android_builder_version = "4.0.1"
+
+ext {
+    android_builder_main_version = Integer.parseInt(android_builder_version.split("\\.")[0])
+    android_builder_mid_version = Integer.parseInt(android_builder_version.split("\\.")[1])
+}
+
 android {
     compileSdkVersion 30
-
+    buildToolsVersion "30.0.3"
     defaultConfig {
         applicationId "com.example.androiddevchallenge"
         minSdkVersion 23
@@ -38,10 +45,13 @@ android {
 
     kotlinOptions {
         jvmTarget = "1.8"
+        useIR = true
     }
 
     buildFeatures {
-        compose true
+        if (android_builder_main_version >= 7 || (android_builder_main_version > 4 && android_builder_mid_version > 1)) {
+            compose true
+        }
 
         // Disable unused AGP features
         buildConfig false
@@ -53,6 +63,7 @@ android {
 
     composeOptions {
         kotlinCompilerExtensionVersion compose_version
+        kotlinCompilerVersion kotlin_version
     }
 
     packagingOptions {
@@ -65,18 +76,21 @@ android {
 
 dependencies {
     implementation 'androidx.core:core-ktx:1.3.2'
-    implementation "androidx.appcompat:appcompat:$appcompat_version"
     implementation 'com.google.android.material:material:1.4.0-beta01'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.1'
+
+    if (android_builder_main_version < 7) {
+        add("kotlinCompilerPluginClasspath", "androidx.compose.compiler:compiler:$compose_version")
+    }
+    implementation "androidx.appcompat:appcompat:$appcompat_version"
     implementation "androidx.activity:activity-compose:$compose_activity_version"
     implementation "androidx.compose.ui:ui:$compose_version"
     implementation "androidx.compose.material:material:$compose_version"
     implementation "androidx.compose.material:material-icons-extended:$compose_version"
     implementation "androidx.compose.ui:ui-tooling:$compose_version"
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.1'
     implementation "androidx.lifecycle:lifecycle-viewmodel-compose:$compose_lifecycle_version"
 
     testImplementation 'junit:junit:4.13.2'
-
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_version"
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -66,13 +66,13 @@ android {
 dependencies {
     implementation 'androidx.core:core-ktx:1.3.2'
     implementation "androidx.appcompat:appcompat:$appcompat_version"
-    implementation 'com.google.android.material:material:1.3.0'
+    implementation 'com.google.android.material:material:1.4.0-beta01'
     implementation "androidx.activity:activity-compose:$compose_activity_version"
     implementation "androidx.compose.ui:ui:$compose_version"
     implementation "androidx.compose.material:material:$compose_version"
     implementation "androidx.compose.material:material-icons-extended:$compose_version"
     implementation "androidx.compose.ui:ui-tooling:$compose_version"
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.0'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.1'
     implementation "androidx.lifecycle:lifecycle-viewmodel-compose:$compose_lifecycle_version"
 
     testImplementation 'junit:junit:4.13.2'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -71,7 +71,7 @@ android {
     }
 
     buildFeatures {
-        if (android_builder_main_version >= 7 || (android_builder_main_version > 4 && android_builder_mid_version > 1)) {
+        if (android_builder_main_version >= 5 || (android_builder_main_version == 4 && android_builder_mid_version >= 3)) {
             compose true
         }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -65,15 +65,15 @@ android {
 
 dependencies {
     implementation 'androidx.core:core-ktx:1.3.2'
-    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation "androidx.appcompat:appcompat:$appcompat_version"
     implementation 'com.google.android.material:material:1.3.0'
-    implementation "androidx.activity:activity-compose:1.3.0-alpha03"
+    implementation "androidx.activity:activity-compose:$compose_activity_version"
     implementation "androidx.compose.ui:ui:$compose_version"
     implementation "androidx.compose.material:material:$compose_version"
     implementation "androidx.compose.material:material-icons-extended:$compose_version"
     implementation "androidx.compose.ui:ui-tooling:$compose_version"
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.0'
-    implementation "androidx.lifecycle:lifecycle-viewmodel-compose:1.0.0-alpha02"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-compose:$compose_lifecycle_version"
 
     testImplementation 'junit:junit:4.13.2'
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ android {
     compileSdkVersion 30
     buildToolsVersion "30.0.3"
     defaultConfig {
-        applicationId "com.example.androiddevchallenge"
+        applicationId "com.example.androiddevchallenge.petadoption"
         minSdkVersion 23
         targetSdkVersion 30
         versionCode 1

--- a/build.gradle
+++ b/build.gradle
@@ -15,9 +15,12 @@
  */
 
 buildscript {
-    ext.kotlin_version = '1.4.30'
-    ext.compose_version = '1.0.0-beta01'
-    ext.coroutines_version = '1.4.2'
+    ext {
+        android_gradle_plugin_version = '7.0.0-alpha08'
+        kotlin_version = '1.4.30'
+        compose_version = '1.0.0-beta01'
+        coroutines_version = '1.4.2'
+    }
 
     repositories {
         google()
@@ -25,7 +28,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.0-alpha08'
+        classpath "com.android.tools.build:gradle:$android_gradle_plugin_version"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -17,9 +17,9 @@
 buildscript {
     ext {
         android_gradle_plugin_version = '7.0.0-alpha08'
-        kotlin_version = '1.4.30'
-        compose_version = '1.0.0-beta01'
-        coroutines_version = '1.4.2'
+        kotlin_version = '1.5.10'
+        compose_version = '1.0.0-beta09'
+        coroutines_version = '1.4.3'
     }
 
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -20,9 +20,9 @@ buildscript {
         kotlin_version = '1.5.10'
         compose_version = '1.0.0-beta09'
         coroutines_version = '1.4.3'
-        compose_appcompat_version = '1.2.0'
+        compose_appcompat_version = '1.3.0'
         appcompat_version = compose_appcompat_version
-        compose_activity_version = '1.3.0-alpha03'
+        compose_activity_version = '1.3.0-beta01'
         compose_lifecycle_version = '1.0.0-alpha06'
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,10 @@ buildscript {
         kotlin_version = '1.5.10'
         compose_version = '1.0.0-beta09'
         coroutines_version = '1.4.3'
+        compose_appcompat_version = '1.2.0'
+        appcompat_version = compose_appcompat_version
+        compose_activity_version = '1.3.0-alpha03'
+        compose_lifecycle_version = '1.0.0-alpha06'
     }
 
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@
 
 buildscript {
     ext {
-        android_gradle_plugin_version = '7.0.0-alpha08'
+        android_gradle_plugin_version = '4.1.2'
         kotlin_version = '1.5.10'
         compose_version = '1.0.0-beta09'
         coroutines_version = '1.4.3'
@@ -57,5 +57,29 @@ subprojects {
             ktlint("0.40.0")
             licenseHeaderFile rootProject.file('spotless/copyright.kt')
         }
+    }
+
+    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+        kotlinOptions {
+            // Treat all Kotlin warnings as errors
+            allWarningsAsErrors = false
+
+            freeCompilerArgs += '-Xopt-in=kotlin.RequiresOptIn'
+
+            // Enable experimental coroutines APIs, including Flow
+            freeCompilerArgs += '-Xopt-in=kotlinx.coroutines.ExperimentalCoroutinesApi'
+            freeCompilerArgs += '-Xopt-in=kotlinx.coroutines.FlowPreview'
+            freeCompilerArgs += '-Xopt-in=kotlin.Experimental'
+
+            // Set JVM target to 1.8
+            jvmTarget = "1.8"
+            //JetPack Compose enable
+            useIR = true
+        }
+    }
+
+    tasks.withType( JavaCompiler).configureEach {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Feb 24 18:05:51 CET 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,2 @@
-rootProject.name = "AndroidDevChallenge"
+rootProject.name = "PetAdoptionCompose"
 include ':app'


### PR DESCRIPTION
Dear Sir

i  upgrade Compose relation library 

& modify build gradle  let AS 4.0.X~4.2.X stable version support Compose

PS .  but  use  Compose 1.0.0-beta09 at some low level Android Device will get crash -- libart.so crash 

replace to 1.0.0-beta08 it`s ok !!

PS . at sugar P1  get libart.so crash 

THX